### PR TITLE
feat: 카테고리 컴포넌트 수정

### DIFF
--- a/src/components/common/category/Category.jsx
+++ b/src/components/common/category/Category.jsx
@@ -1,18 +1,7 @@
 import React, { useState } from "react";
 import * as C from "./Category.style";
 
-const CATEGORY = [
-  { id: 1, label: "조소" },
-  { id: 2, label: "한국화" },
-  { id: 3, label: "동양화" },
-  { id: 4, label: "서양화" },
-  { id: 5, label: "일러스트" },
-  { id: 6, label: "디자인" },
-  { id: 7, label: "공예" },
-  { id: 8, label: "수채화" },
-];
-
-function Category({ chips=CATEGORY, title="카테고리" }) {
+function Category({ chips, title }) {
 
     const [chipClicked, setChipClicked] = useState(() => {
         const initialState = Object.fromEntries(

--- a/src/components/common/category/Category.jsx
+++ b/src/components/common/category/Category.jsx
@@ -1,17 +1,24 @@
 import React, { useState } from "react";
 import * as C from "./Category.style";
 
-function Category() {
+const CATEGORY = [
+  { id: 1, label: "조소" },
+  { id: 2, label: "한국화" },
+  { id: 3, label: "동양화" },
+  { id: 4, label: "서양화" },
+  { id: 5, label: "일러스트" },
+  { id: 6, label: "디자인" },
+  { id: 7, label: "공예" },
+  { id: 8, label: "수채화" },
+];
 
-    const [chipClicked, setChipClicked] = useState({
-        조소: false,
-        한국화: false,
-        동양화: false,
-        서양화: false,
-        일러스트: false,
-        디자인: false,
-        공예: false,
-        수채화: false
+function Category({ chips=CATEGORY, title="카테고리" }) {
+
+    const [chipClicked, setChipClicked] = useState(() => {
+        const initialState = Object.fromEntries(
+          Object.keys(chips).map((label) => [label, false])
+        );
+        return initialState;
     });
 
     const handleChipClick = (label) => {
@@ -23,53 +30,28 @@ function Category() {
 
     return(
         <C.Wrapper>
-            <C.Title>
-                카테고리
-            </C.Title>
-            <C.ChipTop>
-                <C.CustomChip
-                    label="조소"
-                    onClick={() => handleChipClick("조소")}
-                    color={chipClicked["조소"] ? "primary" : "default"}
-                />
-                <C.CustomChip
-                    label="한국화"
-                    onClick={() => handleChipClick("한국화")}
-                    color={chipClicked["한국화"] ? "primary" : "default"}
-                />
-                <C.CustomChip
-                    label="동양화"
-                    onClick={() => handleChipClick("동양화")}
-                    color={chipClicked["동양화"] ? "primary" : "default"}
-                />
-                <C.CustomChip
-                    label="서양화"
-                    onClick={() => handleChipClick("서양화")}
-                    color={chipClicked["서양화"] ? "primary" : "default"}
-                />
-            </C.ChipTop>
-            <C.ChipBottom>
-                <C.CustomChip
-                    label="일러스트"
-                    onClick={() => handleChipClick("일러스트")}
-                    color={chipClicked["일러스트"] ? "primary" : "default"}
-                />
-                <C.CustomChip
-                    label="디자인"
-                    onClick={() => handleChipClick("디자인")}
-                    color={chipClicked["디자인"] ? "primary" : "default"}
-                />
-                <C.CustomChip
-                    label="공예"
-                    onClick={() => handleChipClick("공예")}
-                    color={chipClicked["공예"] ? "primary" : "default"}
-                />
-                <C.CustomChip
-                    label="수채화"
-                    onClick={() => handleChipClick("수채화")}
-                    color={chipClicked["수채화"] ? "primary" : "default"}
-                />
-            </C.ChipBottom>
+            <C.Title>{title}</C.Title>
+            {chips.map((chip) => (
+        <React.Fragment key={chip.id}>
+        {chip.id < 4 ? (
+          <C.ChipTop>
+            <C.CustomChip
+              label={chip.label}
+              onClick={() => handleChipClick(chip.label)}
+              color={chipClicked[chip.label] ? "primary" : "default"}
+            />
+          </C.ChipTop>
+        ) : (
+          <C.ChipBottom>
+            <C.CustomChip
+              label={chip.label}
+              onClick={() => handleChipClick(chip.label)}
+              color={chipClicked[chip.label] ? "primary" : "default"}
+            />
+          </C.ChipBottom>
+        )}
+      </React.Fragment>
+      ))}
         </C.Wrapper>
     )
 }

--- a/src/components/common/category/Category.style.js
+++ b/src/components/common/category/Category.style.js
@@ -1,13 +1,12 @@
 import styled from "styled-components";
 import { Chip } from '@mui/material';
 
-export const Wrapper = styled.div`
-    margin-left: 20px;
-    margin-right: 20px;
-`
 export const Title = styled.div`
-    font-size: 13px;
-    font-weight: 600;
+    color: #000;
+    font-size: 1.3rem;
+    font-style: normal;
+    font-weight: 500;
+    line-height: normal;
     margin-top: 1rem;
     margin-bottom: 1rem;
 `
@@ -22,8 +21,10 @@ export const ChipBottom = styled.div`
 `
 
 export const CustomChip = styled(Chip)`
-    font-size: 14px;
-    font-weight: 600;
+    font-size: 1.4rem;
+    font-weight: 500;
+    line-height: normal;
+    text-align: center;
     height: 3rem;
     padding: 1rem;
     margin: 10rem;


### PR DESCRIPTION
## 관련 이슈
#61 

<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

## 구현 기능 및 변경 사항
<!-- 구현한 내용에 대해 설명해주세요 -->
- 카테고리 컴포넌트 범용적으로 사용 가능하게 props 설정 완료

< 미완성 부분 >
- props을 활용한 로직으로 변경했더니, div flex 정렬이 잘 안 되고 있습니다..ㅜㅜ
Top 행에 chip 4개, Bottom 행에 chip 4개가 정렬되어야 합니다
chip이 4개 이하일 때는, Top행만 보여지게 하는 로직입니다

## 테스트 방법(선택)

<!-- 어느 브랜치인지 이동 / 어떤 동작을 하는지 테스트하는 방법을 설명해주세요 -->

## 스크린샷(선택)
![image](https://github.com/UMC-BRUSHWORK/frontend/assets/138510934/f6034184-7a99-42e7-8b4a-77e1e26cf48e)
