### PR TITLE
feature: 구매내역 페이지 생성

### DIFF
--- a/src/components/common/artwork/PurchasedArtWorkInfo.jsx
+++ b/src/components/common/artwork/PurchasedArtWorkInfo.jsx
@@ -9,7 +9,7 @@ function PurchasedArtWorkInfo({ img, name, artist, price }) {
       <A.PurchasedArtWrapper>
         <A.PurchasedArtName>{name}</A.PurchasedArtName>
         <A.PurchasedArtistName>{artist}</A.PurchasedArtistName>
-        <A.PurchasedArtPrice>{price.toLocaleString()}원</A.PurchasedArtPrice>
+        <A.PurchasedArtPrice>{price}원</A.PurchasedArtPrice>
         <ReviewWriteButton />
       </A.PurchasedArtWrapper>
     </A.PurchasedArtInfoWrapper>

--- a/src/components/common/artwork/PurchasedArtWorkInfo.style.js
+++ b/src/components/common/artwork/PurchasedArtWorkInfo.style.js
@@ -5,6 +5,7 @@ import color from '../../../styles/color';
 export const PurchasedArtInfoWrapper = styled.div`
   display: flex;
   margin-top: 1.7rem;
+  margin-left: 1.6rem;
 `;
 
 export const PurchasedArtworkImage = styled.img`
@@ -26,7 +27,7 @@ export const PurchasedArtName = styled.h1`
 `;
 
 export const PurchasedArtistName = styled.p`
-  color: ${color.gray};
+  color: ${color.grayscale_6c};
   ${() => font.regular_10}
   margin-top: 0.2rem;
 `;

--- a/src/components/common/bar/PurchasedBar.style.js
+++ b/src/components/common/bar/PurchasedBar.style.js
@@ -6,6 +6,7 @@ import color from '../../../styles/color';
 export const TabContainer = styled.div`
   display: flex;
   position: relative;
+  margin-top: 2.4rem;
 `;
 
 export const TabButton = styled.div`

--- a/src/components/common/topbar/PurchasedTopbar.jsx
+++ b/src/components/common/topbar/PurchasedTopbar.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import * as T from './Topbar.style';
+import IMAGES from '../../../assets';
+
+function PurchasedTopbar() {
+  return (
+    <T.Wrapper>
+      <T.Left>
+        <T.Icon src={IMAGES.arrowBack} />
+        <T.LogoText>구매 내역</T.LogoText>
+      </T.Left>
+    </T.Wrapper>
+  );
+}
+
+export default PurchasedTopbar;

--- a/src/components/common/topbar/Topbar.jsx
+++ b/src/components/common/topbar/Topbar.jsx
@@ -9,7 +9,7 @@ function Topbar() {
   return (
     <T.Wrapper>
       <T.Left>
-        <T.Icon src={IMAGES.ArrowBack} />
+        <T.Icon src={IMAGES.arrowBack} />
       </T.Left>
       <T.Right>
         <T.IconWrapper>

--- a/src/components/common/topbar/Topbar.style.js
+++ b/src/components/common/topbar/Topbar.style.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import font from '../../../styles/font';
 
 export const Wrapper = styled.div`
   width: 100%;
@@ -13,6 +14,11 @@ export const Wrapper = styled.div`
 
 export const Left = styled.div`
   display: flex;
+`;
+
+export const LogoText = styled.div`
+  ${() => font.medium_19};
+  margin-left: 1.2rem;
 `;
 
 export const Right = styled.div`

--- a/src/pages/myPage/MyReview.jsx
+++ b/src/pages/myPage/MyReview.jsx
@@ -6,7 +6,7 @@ export default function MyReview() {
   return (
     <>
       <PurchasedBar />
-      <WrittenReview reviewData={dummyData} />
+      <WrittenReview />
     </>
   );
 }

--- a/src/pages/myPage/Purchased.jsx
+++ b/src/pages/myPage/Purchased.jsx
@@ -1,6 +1,38 @@
 import React from 'react';
+import styled from 'styled-components';
 import PurchasedBar from '../../components/common/bar/PurchasedBar';
+import Header from '../../components/common/header/Header';
+import BottomNav from '../../components/common/bottomNav/BottomNav';
+import PurchasedArtWorkInfo from '../../components/common/artwork/PurchasedArtWorkInfo';
+import IMAGES from '../../assets';
 
+const Wrapper = styled.div`
+  height: calc(100vh - 11.2rem);
+
+  justify-content: center;
+  align-items: center;
+`;
 export default function Purchased() {
-  return <PurchasedBar />;
+  const artworkData = {
+    img: IMAGES.artWork6,
+    name: '작품 이름',
+    artist: '작가명',
+    price: 100000,
+  };
+
+  return (
+    <>
+      <Header />
+      <Wrapper>
+        <PurchasedBar />
+        <PurchasedArtWorkInfo
+          img={artworkData.img}
+          name={artworkData.name}
+          artist={artworkData.artist}
+          price={artworkData.price.toLocaleString()}
+        />
+      </Wrapper>
+      <BottomNav />
+    </>
+  );
 }

--- a/src/pages/myPage/Purchased.jsx
+++ b/src/pages/myPage/Purchased.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import PurchasedBar from '../../components/common/bar/PurchasedBar';
-import Header from '../../components/common/header/Header';
-import BottomNav from '../../components/common/bottomNav/BottomNav';
+import PurchasedTopbar from '../../components/common/topbar/PurchasedTopbar';
 import PurchasedArtWorkInfo from '../../components/common/artwork/PurchasedArtWorkInfo';
 import IMAGES from '../../assets';
 
@@ -22,7 +21,7 @@ export default function Purchased() {
 
   return (
     <>
-      <Header />
+      <PurchasedTopbar />
       <Wrapper>
         <PurchasedBar />
         <PurchasedArtWorkInfo
@@ -32,7 +31,6 @@ export default function Purchased() {
           price={artworkData.price.toLocaleString()}
         />
       </Wrapper>
-      <BottomNav />
     </>
   );
 }


### PR DESCRIPTION
## 관련 이슈

closed #50

## 구현 기능 및 변경 사항

컴포넌트 합쳐서 구매내역 페이지 생성

## 스크린샷(선택)
<img width="492" alt="스크린샷 2024-01-24 오후 5 53 50" src="https://github.com/UMC-BRUSHWORK/frontend/assets/70011821/9a05342b-bd79-40ca-9e82-56edfeed3287">
