### PR TITLE
feat: 작품 상세 페이지 하단 버튼 api 연동

### DIFF
--- a/src/pages/artwork/artworkDetail/ArtworkDetail.jsx
+++ b/src/pages/artwork/artworkDetail/ArtworkDetail.jsx
@@ -86,7 +86,6 @@ function ArtworkDetail() {
     getProductId(productId);
     getProducts({ cursorId, paging });
   }, [productId]);
-
   const clickButton = async () => {
     try {
       const createRoomRes = await postCreateRoom({
@@ -146,12 +145,17 @@ function ArtworkDetail() {
         )}
         <ReviewList data={reviewDummy} />
       </A.Wrapper>
-      <A.BottomWrapper>
-        <A.FavoriteBtn>
-          <Favorite favorStatus={favorite} productId={productId} />
-        </A.FavoriteBtn>
-        <A.AskBtn onClick={clickButton}>문의하기</A.AskBtn>
-      </A.BottomWrapper>
+        {Number(userId) === productInfo.authorId ? 
+          <A.BottomWrapper>
+            <A.CompleteBtn>판매완료</A.CompleteBtn>
+          </A.BottomWrapper> : 
+          <A.BottomWrapper>
+            <A.FavoriteBtn>
+            <Favorite favorStatus={favorite} productId={productId} />
+            </A.FavoriteBtn>
+            <A.AskBtn onClick={clickButton}>문의하기</A.AskBtn>
+          </A.BottomWrapper>
+        }
     </Wrapper>
   );
 }


### PR DESCRIPTION
## 관련 이슈
resolved #180 

<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

## 구현 기능 및 변경 사항

<!-- 구현한 내용에 대해 설명해주세요 -->
- 작품 상세 페이지 하단 버튼 api 연동
- localstorage에 있는 userId와 작품의 authorId가 같을 때 -> 판매완료 버튼
- ㄴ 서로 다를 때 -> 문의하기 버튼

## 테스트 방법(선택)

<!-- 어느 브랜치인지 이동 / 어떤 동작을 하는지 테스트하는 방법을 설명해주세요 -->

## 스크린샷(선택)
![스크린샷 2024-02-18 154602](https://github.com/UMC-BRUSHWORK/frontend/assets/138510934/dd25b090-28f7-410c-8c50-76dcfbdb9a64)
![스크린샷 2024-02-18 154622](https://github.com/UMC-BRUSHWORK/frontend/assets/138510934/8f472819-b873-4a75-b68e-c2196efe85fd)
